### PR TITLE
Fix a typo in the definition of poly_eq

### DIFF
--- a/implementations/polynomials.v
+++ b/implementations/polynomials.v
@@ -21,7 +21,7 @@ Section contents.
     match p, q with
     | [], _ => poly_eq_zero q
     | _, [] => poly_eq_zero p
-    | h :: t, h' :: t' => h = h ∧ F t t'
+    | h :: t, h' :: t' => h = h' ∧ F t t'
     end.
 
 (*


### PR DESCRIPTION
With the previous definition, any two polynomials of the same degree were equal.