### PR TITLE
Fix definition of equivalence of polynomials

### DIFF
--- a/implementations/polynomials.v
+++ b/implementations/polynomials.v
@@ -21,7 +21,7 @@ Section contents.
     match p, q with
     | [], _ => poly_eq_zero q
     | _, [] => poly_eq_zero p
-    | h :: t, h' :: t' => h = h ∧ F t t'
+    | h :: t, h' :: t' => h = h' ∧ F t t'
     end.
 
 (*


### PR DESCRIPTION
The definition should compare the first two elements of both polynomials, not the first element of one of them with itself.