### PR TITLE
fix compilation with Coq trunk

### DIFF
--- a/categories/dual.v
+++ b/categories/dual.v
@@ -34,6 +34,13 @@ Section contents.
 
 End contents.
 
+(** Avoid looping on applications of e, without making flipA opaque.
+   Note that the dual instances make proof search slower in general,
+   making flipA opaque for resolution would speed things up but require
+   a few changes to the scripts to explicitly convert terms to applications
+   of flipA. *)
+Hint Cut [_* e (_*) e] : typeclass_instances.
+
 Section functors.
 
   (** Given a functor F: C → D, we have a functor F^op: C^op → D^op *)

--- a/misc/decision.v
+++ b/misc/decision.v
@@ -22,7 +22,7 @@ Ltac solve_decision :=
   first [solve_trivial_decision | unfold Decision; decide equality; solve_trivial_decision].
 
 (* We cannot state this as Proper (iff ==> iffT) Decision due to the lack of setoid rewriting in Type *)
-Program Instance decision_proper (P Q : Prop) (PiffQ : P ↔ Q) (P_dec : Decision P) : Decision Q :=
+Program Definition decision_proper (P Q : Prop) (PiffQ : P ↔ Q) (P_dec : Decision P) : Decision Q :=
   match P_dec with
   | left _ => left _
   | right _ => right _


### PR DESCRIPTION
This pull request represents the merge of the `v8.6` branch into `master` branch; nothing more.

The reason why I think it make sense to do it is that the present state of the published `master` branch is not compilable (unless `v8.6` branch is merged to it). The currently hangs [here](https://github.com/math-classes/math-classes/blob/v8.5/theory/adjunctions.v#L62).