### PR TITLE
math-classes : switch to the external Bignums library

### DIFF
--- a/implementations/NType_naturals.v
+++ b/implementations/NType_naturals.v
@@ -1,7 +1,7 @@
 Require
   MathClasses.implementations.stdlib_binary_integers MathClasses.theory.integers MathClasses.orders.semirings.
 Require Import
-  Coq.Setoids.Setoid Coq.Numbers.Natural.SpecViaZ.NSig Coq.Numbers.Natural.SpecViaZ.NSigNAxioms Coq.NArith.NArith Coq.ZArith.ZArith Coq.Program.Program Coq.Classes.Morphisms
+  Coq.Setoids.Setoid Bignums.SpecViaZ.NSig Bignums.SpecViaZ.NSigNAxioms Coq.NArith.NArith Coq.ZArith.ZArith Coq.Program.Program Coq.Classes.Morphisms
   MathClasses.interfaces.abstract_algebra MathClasses.interfaces.naturals MathClasses.interfaces.integers
   MathClasses.interfaces.orders MathClasses.interfaces.additional_operations.
 

--- a/implementations/QType_rationals.v
+++ b/implementations/QType_rationals.v
@@ -1,7 +1,7 @@
 Require
   MathClasses.theory.fields MathClasses.implementations.stdlib_rationals MathClasses.theory.int_pow.
 Require Import
-  Coq.QArith.QArith Coq.Numbers.Rational.SpecViaQ.QSig
+  Coq.QArith.QArith Bignums.SpecViaQ.QSig
   MathClasses.interfaces.abstract_algebra MathClasses.interfaces.orders
   MathClasses.interfaces.integers MathClasses.interfaces.rationals MathClasses.interfaces.additional_operations
   MathClasses.theory.rings MathClasses.theory.rationals.

--- a/implementations/ZType_integers.v
+++ b/implementations/ZType_integers.v
@@ -1,7 +1,7 @@
 Require
   MathClasses.implementations.stdlib_binary_integers MathClasses.theory.integers MathClasses.orders.semirings.
 Require Import
-  Coq.Numbers.Integer.SpecViaZ.ZSig Coq.Numbers.Integer.SpecViaZ.ZSigZAxioms Coq.NArith.NArith Coq.ZArith.ZArith
+  Bignums.SpecViaZ.ZSig Bignums.SpecViaZ.ZSigZAxioms Coq.NArith.NArith Coq.ZArith.ZArith
   MathClasses.implementations.nonneg_integers_naturals MathClasses.interfaces.orders
   MathClasses.interfaces.abstract_algebra MathClasses.interfaces.integers MathClasses.interfaces.additional_operations.
 

--- a/implementations/fast_integers.v
+++ b/implementations/fast_integers.v
@@ -1,5 +1,5 @@
 Require Import
-  Coq.Numbers.Integer.BigZ.BigZ
+  Bignums.BigZ.BigZ
   MathClasses.interfaces.abstract_algebra MathClasses.interfaces.integers
   MathClasses.interfaces.additional_operations MathClasses.implementations.fast_naturals.
 Require Export

--- a/implementations/fast_naturals.v
+++ b/implementations/fast_naturals.v
@@ -1,5 +1,5 @@
 Require Import
-  Coq.Numbers.Natural.BigN.BigN MathClasses.interfaces.naturals.
+  Bignums.BigN.BigN MathClasses.interfaces.naturals.
 Require Export
   MathClasses.implementations.NType_naturals.
 

--- a/implementations/fast_rationals.v
+++ b/implementations/fast_rationals.v
@@ -1,7 +1,7 @@
 Require
   MathClasses.theory.shiftl MathClasses.theory.int_pow.
 Require Import
-  Coq.QArith.QArith Coq.Numbers.Rational.BigQ.BigQ
+  Coq.QArith.QArith Bignums.BigQ.BigQ
   MathClasses.interfaces.abstract_algebra
   MathClasses.interfaces.integers MathClasses.interfaces.rationals MathClasses.interfaces.additional_operations
   MathClasses.implementations.fast_naturals MathClasses.implementations.fast_integers MathClasses.implementations.field_of_fractions MathClasses.implementations.stdlib_rationals.


### PR DESCRIPTION
In prevision for Coq 8.7, where the `bignums` library is going to be an external package, you might want to push the following commit in a v8.7 branch of math-classes. See [PR #498](https://github.com/coq/coq/pull/498)

The external `bignum` package is already available this way (an opam package is underway) :
```
 git clone https://github.com/coq/bignums.git && cd bignums && make && make install
```
The above command is for the trunk-compatible version of bignum, there is also a v8.6 branch there.
