### PR TITLE
Fix #51: `cofix` tactic without a name is deprecated.

### DIFF
--- a/theory/streams.v
+++ b/theory/streams.v
@@ -92,7 +92,7 @@ Lemma ForAll_tl (P : ∞A → Prop) s : ForAll P s → ForAll P (tl s).
 Proof. apply (ForAll_Str_nth_tl 1). Qed.
 
 Lemma ForAll_True (s : ∞A) : ForAll (λ _, True) s.
-Proof. revert s. cofix. intros. constructor; trivial. Qed.
+Proof. revert s. cofix F. intros. constructor; trivial. Qed.
 
 Definition EventuallyForAll (P : ∞A → Prop) := ForAll (λ s, P s → P (tl s)).
 


### PR DESCRIPTION
Backward compatible change.

Fixes #51.